### PR TITLE
Use sentry sdk instead of raven

### DIFF
--- a/django_q_sentry/sentry.py
+++ b/django_q_sentry/sentry.py
@@ -1,10 +1,10 @@
-import raven
+import sentry_sdk
 
 
 class Sentry(object):
 
     def __init__(self, dsn, **kwargs):
-        self.client = raven.Client(dsn, **kwargs)
+        self.client = sentry_sdk.init(dsn=dsn, **kwargs)
 
     def report(self):
-        self.client.captureException()
+        sentry_sdk.capture_exception()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-raven==6.0.0
+sentry-sdk==0.10.*


### PR DESCRIPTION
Uses sentry's python client instead of the deprecated raven client.

From https://docs.sentry.io/error-reporting/capturing/?platform=python, I believe `capture_exception` works similarly to `captureException`, but I'll need to test.
