### PR TITLE
Don't call sentry sdk init

### DIFF
--- a/django_q_sentry/sentry.py
+++ b/django_q_sentry/sentry.py
@@ -41,9 +41,6 @@ def return_task_from_stack(tb) -> dict:
 
 class Sentry(object):
 
-    def __init__(self, dsn, **kwargs):
-        sentry_sdk.init(dsn, **kwargs)
-
     def report(self):
         error = sys.exc_info()
         tb = error[2]


### PR DESCRIPTION
As described in #12 initializing django-q-sentry overrides any previous sentry config. I think it is better no to call sentry init implicitly and to leave calling sentry initialization to the user of the library.